### PR TITLE
Add delivery note endpoint

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -69,6 +69,22 @@ app.MapGet("/weatherforecast", () =>
 })
 .WithName("GetWeatherForecast");
 
+app.MapGet("/delivery-note", () =>
+{
+    string rptPath = Path.Combine(AppContext.BaseDirectory, "Reports", "DeliveryNote.rpt");
+    ReportDocument report = new();
+    report.Load(rptPath);
+
+    // Configure connection to SAP HANA using the HDBODBC32 driver
+    // Replace placeholders with your connection details
+    report.SetDatabaseLogon("hanauser", "hanapassword", "HANASERVER", "HANADB");
+
+    Stream pdf = report.ExportToStream(ExportFormatType.PortableDocFormat);
+    pdf.Position = 0;
+    return Results.File(pdf, "application/pdf", "delivery-note.pdf");
+})
+.WithName("GetDeliveryNote");
+
 app.Run();
 
 record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)


### PR DESCRIPTION
## Summary
- add minimal API endpoint `/delivery-note` to load a `.rpt` file, connect to SAP HANA and return a PDF

## Testing
- `dotnet build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68460f948f68833292494846ca718989